### PR TITLE
Allow newer versions of psr/log

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
 	},
 	"require": {
 		"php": ">=7.4.0",
-		"psr/log": "^1.0"
+		"psr/log": "^1.0|^2.0|^3.0"
 	},
 	"require-dev": {
 		"mediawiki/mediawiki-codesniffer": "46.0.0",


### PR DESCRIPTION
The code of `PhpSessionSerializer` is compatible with all versions of psr/log. Versions ^2.0 restrict the input type of the methods in the `LoggerInterface` to `string|\Stringable`, which is fine, because everything that the `PhpSessionSerializer` passes to those methods is a string. Versions ^3.0 of the package restrict the return type of the methods in the `LoggerInterface` to `void`, which is fine, because the `PhpSessionSerializer` does not expect any of those methods to return anything. Since versions ^1.0 are still allowed this change is backwards compatible.